### PR TITLE
BUG-004: Improve nginx upstream configuration for backend proxy

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -208,4 +208,3 @@ server {
 #         deny all;
 #     }
 # }
-# }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,10 +7,38 @@
 #   3. 配置 SSL 后：取消 HTTPS 部分注释，注释 HTTP 部分
 # ============================================================
 
+# Backend upstream configuration
+upstream backend {
+    server backend:3000;
+    keepalive 32;
+    keepalive_timeout 60s;
+}
+
 # HTTP 配置（首次部署使用，或用于重定向到 HTTPS）
 server {
     listen 80;
     server_name _;  # 匹配所有域名，部署后改为你的域名如: medical.example.com
+
+    # 允许上传大文件（50MB）
+    client_max_body_size 50M;
+
+    # Custom error pages for backend errors
+    error_page 502 /502.html;
+    error_page 503 /503.html;
+    error_page 504 /504.html;
+
+    location = /502.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
+    location = /503.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
+    location = /504.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
     
     # === 启用 HTTPS 后，取消下面这行注释 ===
     # return 301 https://$host$request_uri;
@@ -30,7 +58,7 @@ server {
     
     # API 反向代理
     location /api/ {
-        proxy_pass http://backend:3000/api/;
+        proxy_pass http://backend/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -39,21 +67,37 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
-        
+
+        # Passive health checking - retry on transient errors
+        proxy_next_upstream error timeout http_502 http_503 http_504;
+        proxy_next_upstream_tries 2;
+        proxy_next_upstream_timeout 10s;
+
         # 超时设置
-        proxy_connect_timeout 60s;
+        proxy_connect_timeout 10s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
-        
-        # 文件上传大小限制
-        client_max_body_size 50M;
     }
     
     # 上传文件访问
     location /uploads/ {
-        proxy_pass http://backend:3000/uploads/;
+        proxy_pass http://backend/uploads/;
+        proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Passive health checking - retry on transient errors
+        proxy_next_upstream error timeout http_502 http_503 http_504;
+        proxy_next_upstream_tries 2;
+        proxy_next_upstream_timeout 10s;
+
+        # Timeout settings
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+
         expires 7d;
         add_header Cache-Control "public";
     }
@@ -108,7 +152,7 @@ server {
 #     
 #     # API 反向代理
 #     location /api/ {
-#         proxy_pass http://backend:3000/api/;
+#         proxy_pass http://backend/api/;
 #         proxy_http_version 1.1;
 #         proxy_set_header Upgrade $http_upgrade;
 #         proxy_set_header Connection 'upgrade';
@@ -117,17 +161,37 @@ server {
 #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 #         proxy_set_header X-Forwarded-Proto $scheme;
 #         proxy_cache_bypass $http_upgrade;
-#         proxy_connect_timeout 60s;
+#
+#         # Passive health checking - retry on transient errors
+#         proxy_next_upstream error timeout http_502 http_503 http_504;
+#         proxy_next_upstream_tries 2;
+#         proxy_next_upstream_timeout 10s;
+#
+#         # 超时设置
+#         proxy_connect_timeout 10s;
 #         proxy_send_timeout 60s;
 #         proxy_read_timeout 60s;
-#         client_max_body_size 50M;
 #     }
-#     
+#
 #     # 上传文件访问
 #     location /uploads/ {
-#         proxy_pass http://backend:3000/uploads/;
+#         proxy_pass http://backend/uploads/;
+#         proxy_http_version 1.1;
 #         proxy_set_header Host $host;
 #         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#
+#         # Passive health checking - retry on transient errors
+#         proxy_next_upstream error timeout http_502 http_503 http_504;
+#         proxy_next_upstream_tries 2;
+#         proxy_next_upstream_timeout 10s;
+#
+#         # Timeout settings
+#         proxy_connect_timeout 10s;
+#         proxy_send_timeout 60s;
+#         proxy_read_timeout 60s;
+#
 #         expires 7d;
 #         add_header Cache-Control "public";
 #     }

--- a/server/src/test/nginx-upstream.spec.ts
+++ b/server/src/test/nginx-upstream.spec.ts
@@ -1,0 +1,366 @@
+/**
+ * @file Nginx Upstream Configuration Test
+ * @description 验证 nginx upstream 配置和错误页面 - BUG-004
+ *
+ * ## Spec Reference
+ * - PRD BUG-004: Improve nginx upstream configuration for backend proxy
+ * - Acceptance Criteria:
+ *   1. Nginx starts successfully even when backend is temporarily down
+ *   2. Upstream block properly defines backend service with keepalive
+ *   3. Graceful error handling when backend is unreachable
+ *
+ * This test validates nginx configuration files without requiring
+ * database connections or the full NestJS application.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+describe("Nginx Upstream Configuration", () => {
+  const projectRoot = path.join(process.cwd(), "..");
+  const nginxConfPath = path.join(projectRoot, "nginx", "nginx.conf");
+  const webNginxConfPath = path.join(projectRoot, "web", "nginx.conf");
+
+  /**
+   * ## Happy Path: Nginx Configuration Files Exist and Are Valid
+   *
+   * Spec Requirement: Nginx configuration files should exist and contain upstream block
+   * Reference: PRD BUG-004 Acceptance Criteria #2
+   */
+  describe("Nginx Configuration Files", () => {
+    it("nginx/nginx.conf should exist and be readable", () => {
+      expect(fs.existsSync(nginxConfPath)).toBe(true);
+
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+      expect(content.length).toBeGreaterThan(0);
+    });
+
+    it("nginx/nginx.conf should contain upstream backend block", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify upstream block exists
+      expect(content).toContain("upstream backend");
+      expect(content).toContain("server backend:3000");
+      expect(content).toContain("keepalive 32");
+      expect(content).toContain("keepalive_timeout 60s");
+    });
+
+    it("nginx/nginx.conf should reference upstream in proxy_pass", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify proxy_pass uses upstream instead of direct hostname
+      expect(content).toContain("proxy_pass http://backend/");
+      // Should NOT contain direct hostname reference (old pattern)
+      expect(content).not.toContain("proxy_pass http://backend:3000/");
+    });
+
+    it("nginx/nginx.conf should contain error page directives", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify error page directives
+      expect(content).toContain("error_page 502");
+      expect(content).toContain("error_page 503");
+      expect(content).toContain("error_page 504");
+    });
+
+    it("nginx/nginx.conf should contain passive health checking", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify passive health checking directives
+      expect(content).toContain("proxy_next_upstream");
+      expect(content).toContain("proxy_next_upstream_tries");
+      expect(content).toContain("proxy_next_upstream_timeout");
+    });
+
+    it("web/nginx.conf should exist and contain upstream block", () => {
+      expect(fs.existsSync(webNginxConfPath)).toBe(true);
+
+      const content = fs.readFileSync(webNginxConfPath, "utf-8");
+      expect(content).toContain("upstream backend");
+      expect(content).toContain("server backend:3000");
+    });
+
+    it("web/nginx.conf should use upstream in proxy_pass directives", () => {
+      const content = fs.readFileSync(webNginxConfPath, "utf-8");
+
+      // Verify all proxy_pass directives use upstream
+      expect(content).toContain("proxy_pass http://backend/");
+      // Should NOT contain direct hostname references
+      expect(content).not.toContain("proxy_pass http://backend:3000/");
+    });
+  });
+
+  /**
+   * ## Happy Path: Error Pages Exist and Are Valid HTML
+   *
+   * Spec Requirement: Custom error pages for backend failures
+   * Reference: PRD BUG-004 Acceptance Criteria #3
+   */
+  describe("Error Pages", () => {
+    it("web/public/502.html should exist and contain valid HTML", () => {
+      const errorPagePath = path.join(projectRoot, "web", "public", "502.html");
+      expect(fs.existsSync(errorPagePath)).toBe(true);
+
+      const content = fs.readFileSync(errorPagePath, "utf-8");
+
+      // Verify it's valid HTML
+      expect(content).toContain("<!DOCTYPE html>");
+      expect(content).toContain("<html");
+      expect(content).toContain("</html>");
+
+      // Verify it contains expected content
+      expect(content).toContain("502");
+      expect(content).toContain("网关错误");
+    });
+
+    it("web/public/503.html should exist and contain valid HTML", () => {
+      const errorPagePath = path.join(projectRoot, "web", "public", "503.html");
+      expect(fs.existsSync(errorPagePath)).toBe(true);
+
+      const content = fs.readFileSync(errorPagePath, "utf-8");
+
+      // Verify it's valid HTML
+      expect(content).toContain("<!DOCTYPE html>");
+      expect(content).toContain("<html");
+      expect(content).toContain("</html>");
+
+      // Verify it contains expected content
+      expect(content).toContain("503");
+      expect(content).toContain("服务维护中");
+    });
+
+    it("web/public/504.html should exist and contain valid HTML", () => {
+      const errorPagePath = path.join(projectRoot, "web", "public", "504.html");
+      expect(fs.existsSync(errorPagePath)).toBe(true);
+
+      const content = fs.readFileSync(errorPagePath, "utf-8");
+
+      // Verify it's valid HTML
+      expect(content).toContain("<!DOCTYPE html>");
+      expect(content).toContain("<html");
+      expect(content).toContain("</html>");
+
+      // Verify it contains expected content
+      expect(content).toContain("504");
+      expect(content).toContain("网关超时");
+    });
+
+    it("error pages should have retry functionality", () => {
+      const errorPages = ["502.html", "503.html", "504.html"];
+
+      errorPages.forEach((page) => {
+        const errorPagePath = path.join(projectRoot, "web", "public", page);
+        const content = fs.readFileSync(errorPagePath, "utf-8");
+
+        // Verify retry button exists with reload function
+        expect(content).toContain("javascript:location.reload()");
+        expect(content).toContain("重试");
+      });
+    });
+
+    it("error pages should have proper styling", () => {
+      const errorPages = ["502.html", "503.html", "504.html"];
+
+      errorPages.forEach((page) => {
+        const errorPagePath = path.join(projectRoot, "web", "public", page);
+        const content = fs.readFileSync(errorPagePath, "utf-8");
+
+        // Verify CSS styling exists
+        expect(content).toContain("<style>");
+        expect(content).toContain("background: linear-gradient");
+        expect(content).toContain(".error-container");
+        expect(content).toContain(".error-code");
+      });
+    });
+
+    it("error pages should be in Chinese as per project language", () => {
+      const errorPages = [
+        { file: "502.html", title: "网关错误" },
+        { file: "503.html", title: "服务维护中" },
+        { file: "504.html", title: "网关超时" },
+      ];
+
+      errorPages.forEach(({ file, title }) => {
+        const errorPagePath = path.join(projectRoot, "web", "public", file);
+        const content = fs.readFileSync(errorPagePath, "utf-8");
+
+        // Verify Chinese language and content
+        expect(content).toContain('lang="zh-CN"');
+        expect(content).toContain(title);
+      });
+    });
+  });
+
+  /**
+   * ## Configuration Values Verification
+   *
+   * Spec Requirement: Upstream configuration should have proper values
+   * Reference: PRD BUG-004 Acceptance Criteria #2
+   */
+  describe("Upstream Configuration Values", () => {
+    it("upstream keepalive should be set to 32 connections", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify keepalive value
+      expect(content).toMatch(/keepalive\s+32/);
+    });
+
+    it("upstream keepalive_timeout should be set to 60s", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify keepalive_timeout value
+      expect(content).toMatch(/keepalive_timeout\s+60s/);
+    });
+
+    it("proxy_connect_timeout should be 10s (reduced from 60s for faster failover)", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify timeout values were reduced for faster health checking
+      expect(content).toMatch(/proxy_connect_timeout\s+10s/);
+    });
+
+    it("proxy_next_upstream should include error codes", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify health checking includes retry conditions
+      expect(content).toMatch(/proxy_next_upstream\s+error timeout http_502 http_503 http_504/);
+    });
+
+    it("proxy_next_upstream_tries should be set to 2", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify retry attempts
+      expect(content).toMatch(/proxy_next_upstream_tries\s+2/);
+    });
+
+    it("proxy_next_upstream_timeout should be 10s", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify retry timeout
+      expect(content).toMatch(/proxy_next_upstream_timeout\s+10s/);
+    });
+  });
+
+  /**
+   * ## Error Page Configuration Verification
+   *
+   * Spec Requirement: Error pages should be properly configured
+   * Reference: PRD BUG-004 Acceptance Criteria #3
+   */
+  describe("Error Page Configuration", () => {
+    it("nginx.conf should configure all three error pages", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify all error page directives
+      expect(content).toMatch(/error_page\s+502\s+\/502.html/);
+      expect(content).toMatch(/error_page\s+503\s+\/503.html/);
+      expect(content).toMatch(/error_page\s+504\s+\/504.html/);
+    });
+
+    it("error page locations should be marked as internal", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify internal directive (prevents direct access)
+      const internalCount = (content.match(/internal/g) || []).length;
+      expect(internalCount).toBeGreaterThanOrEqual(3);
+    });
+
+    it("error page locations should point to correct root", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Verify error pages are served from html root
+      expect(content).toContain("root /usr/share/nginx/html");
+    });
+  });
+
+  /**
+   * ## All Proxy Locations Should Use Upstream
+   *
+   * Spec Requirement: All proxy_pass directives should use upstream block
+   * Reference: PRD BUG-004 Acceptance Criteria #2
+   */
+  describe("Proxy Configuration Consistency", () => {
+    it("all API proxy locations should use upstream", () => {
+      const content = fs.readFileSync(nginxConfPath, "utf-8");
+
+      // Find all proxy_pass directives
+      const proxyPassMatches = content.matchAll(/proxy_pass\s+([^;]+);/g);
+      const proxyPassTargets = Array.from(proxyPassMatches, (m) => m[1]);
+
+      // All proxy_pass should use upstream (http://backend/)
+      proxyPassTargets.forEach((target) => {
+        // Health endpoint doesn't proxy, so skip
+        if (target.includes("health")) return;
+
+        // Verify uses upstream format (not direct hostname:port)
+        if (target.startsWith("http://")) {
+          expect(target).toMatch(/^http:\/\/backend\/[a-z]+\/$/);
+        }
+      });
+    });
+
+    it("web nginx.conf should also use upstream for all proxies", () => {
+      const content = fs.readFileSync(webNginxConfPath, "utf-8");
+
+      // Find all proxy_pass directives
+      const proxyPassMatches = content.matchAll(/proxy_pass\s+([^;]+);/g);
+      const proxyPassTargets = Array.from(proxyPassMatches, (m) => m[1]);
+
+      // All proxy_pass should use upstream (http://backend/)
+      proxyPassTargets.forEach((target) => {
+        expect(target).toMatch(/^http:\/\/backend\/[a-z.]+\/$/);
+      });
+    });
+
+    it("should not contain any direct backend:3000 references in proxy_pass", () => {
+      const nginxContent = fs.readFileSync(nginxConfPath, "utf-8");
+      const webNginxContent = fs.readFileSync(webNginxConfPath, "utf-8");
+
+      // Find all proxy_pass directives in both files
+      const combinedContent = nginxContent + webNginxContent;
+      const proxyPassMatches = combinedContent.matchAll(/proxy_pass\s+([^;]+);/g);
+      const proxyPassTargets = Array.from(proxyPassMatches, (m) => m[1]);
+
+      // None should use direct hostname:port reference
+      proxyPassTargets.forEach((target) => {
+        expect(target).not.toContain("backend:3000");
+      });
+    });
+  });
+
+  /**
+   * ## Property-based Invariance: Configuration File Consistency
+   *
+   * Tests that both nginx config files follow the same pattern
+   */
+  describe("Configuration Consistency", () => {
+    it("both nginx configs should have identical upstream definitions", () => {
+      const nginxContent = fs.readFileSync(nginxConfPath, "utf-8");
+      const webNginxContent = fs.readFileSync(webNginxConfPath, "utf-8");
+
+      // Extract upstream block from both files
+      const nginxUpstream = nginxContent.match(/upstream backend \{[^}]+\}/)?.[0];
+      const webUpstream = webNginxContent.match(/upstream backend \{[^}]+\}/)?.[0];
+
+      expect(nginxUpstream).toBeDefined();
+      expect(webUpstream).toBeDefined();
+
+      // Both should have same server definition
+      expect(nginxUpstream).toContain("server backend:3000");
+      expect(webUpstream).toContain("server backend:3000");
+
+      // Both should have keepalive settings
+      expect(nginxUpstream).toContain("keepalive 32");
+      expect(webUpstream).toContain("keepalive 32");
+    });
+
+    it("both configs should have health checking in all proxy locations", () => {
+      const nginxContent = fs.readFileSync(nginxConfPath, "utf-8");
+      const webNginxContent = fs.readFileSync(webNginxConfPath, "utf-8");
+
+      // Both should have health checking directives
+      expect(nginxContent).toContain("proxy_next_upstream");
+      expect(webNginxContent).toContain("proxy_next_upstream");
+    });
+  });
+});

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,8 +1,33 @@
+# Backend upstream configuration
+upstream backend {
+    server backend:3000;
+    keepalive 32;
+    keepalive_timeout 60s;
+}
+
 server {
     listen 80;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
+
+    # Custom error pages for backend errors
+    error_page 502 /502.html;
+    error_page 503 /503.html;
+    error_page 504 /504.html;
+
+    location = /502.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
+    location = /503.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
+    location = /504.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
 
     # 允许上传大文件（50MB）
     client_max_body_size 50M;
@@ -22,7 +47,7 @@ server {
 
     # API 代理（可选，如果需要前端直接代理到后端）
     location /api/ {
-        proxy_pass http://backend:3000/api/;
+        proxy_pass http://backend/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -31,11 +56,21 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
+
+        # Passive health checking - retry on transient errors
+        proxy_next_upstream error timeout http_502 http_503 http_504;
+        proxy_next_upstream_tries 2;
+        proxy_next_upstream_timeout 10s;
+
+        # Timeout settings
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
     }
 
     # WebSocket (Socket.IO) 代理
     location /socket.io/ {
-        proxy_pass http://backend:3000/socket.io/;
+        proxy_pass http://backend/socket.io/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -45,16 +80,36 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 86400;
+
+        # Passive health checking - retry on transient errors
+        proxy_next_upstream error timeout http_502 http_503 http_504;
+        proxy_next_upstream_tries 2;
+        proxy_next_upstream_timeout 10s;
+
+        # Timeout settings
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
     }
 
     # 上传文件代理（PDF等静态文件）
     location /uploads/ {
-        proxy_pass http://backend:3000/uploads/;
+        proxy_pass http://backend/uploads/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Passive health checking - retry on transient errors
+        proxy_next_upstream error timeout http_502 http_503 http_504;
+        proxy_next_upstream_tries 2;
+        proxy_next_upstream_timeout 10s;
+
+        # Timeout settings
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+
         # 缓存静态文件
         proxy_cache_valid 200 1d;
         expires 1d;

--- a/web/public/502.html
+++ b/web/public/502.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>服务暂时不可用 - 医学宝典</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #333;
+        }
+        .error-container {
+            background: white;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+            text-align: center;
+            max-width: 500px;
+        }
+        .error-code {
+            font-size: 72px;
+            font-weight: bold;
+            color: #667eea;
+            margin: 0;
+        }
+        .error-title {
+            font-size: 24px;
+            margin: 20px 0 10px;
+            color: #333;
+        }
+        .error-message {
+            color: #666;
+            line-height: 1.6;
+            margin-bottom: 30px;
+        }
+        .retry-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: #667eea;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            transition: background 0.3s;
+        }
+        .retry-button:hover {
+            background: #5568d3;
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <div class="error-code">502</div>
+        <h1 class="error-title">网关错误</h1>
+        <p class="error-message">
+            后端服务暂时无法响应。这可能是由于服务器维护或网络问题导致的。
+            <br><br>
+            请稍后重试，或联系技术支持。
+        </p>
+        <a href="javascript:location.reload()" class="retry-button">重试</a>
+    </div>
+</body>
+</html>

--- a/web/public/503.html
+++ b/web/public/503.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>服务维护中 - 医学宝典</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #333;
+        }
+        .error-container {
+            background: white;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+            text-align: center;
+            max-width: 500px;
+        }
+        .error-code {
+            font-size: 72px;
+            font-weight: bold;
+            color: #667eea;
+            margin: 0;
+        }
+        .error-title {
+            font-size: 24px;
+            margin: 20px 0 10px;
+            color: #333;
+        }
+        .error-message {
+            color: #666;
+            line-height: 1.6;
+            margin-bottom: 30px;
+        }
+        .retry-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: #667eea;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            transition: background 0.3s;
+        }
+        .retry-button:hover {
+            background: #5568d3;
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <div class="error-code">503</div>
+        <h1 class="error-title">服务维护中</h1>
+        <p class="error-message">
+            服务正在进行维护升级，暂时无法处理请求。
+            <br><br>
+            请稍后重试，给您带来的不便敬请谅解。
+        </p>
+        <a href="javascript:location.reload()" class="retry-button">重试</a>
+    </div>
+</body>
+</html>

--- a/web/public/504.html
+++ b/web/public/504.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>网关超时 - 医学宝典</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #333;
+        }
+        .error-container {
+            background: white;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+            text-align: center;
+            max-width: 500px;
+        }
+        .error-code {
+            font-size: 72px;
+            font-weight: bold;
+            color: #667eea;
+            margin: 0;
+        }
+        .error-title {
+            font-size: 24px;
+            margin: 20px 0 10px;
+            color: #333;
+        }
+        .error-message {
+            color: #666;
+            line-height: 1.6;
+            margin-bottom: 30px;
+        }
+        .retry-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: #667eea;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            transition: background 0.3s;
+        }
+        .retry-button:hover {
+            background: #5568d3;
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <div class="error-code">504</div>
+        <h1 class="error-title">网关超时</h1>
+        <p class="error-message">
+            服务器响应时间过长，请求已超时。
+            <br><br>
+            请稍后重试，或检查网络连接后再次尝试。
+        </p>
+        <a href="javascript:location.reload()" class="retry-button">重试</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
# Task: BUG-004 - Improve nginx upstream configuration for backend proxy

## Description
Frontend nginx uses proxy_pass with direct hostname reference instead of an upstream block. This causes nginx to fail immediately when backend service is unavailable or restarting. While the current configuration works when both services are healthy, it should be more robust for service discovery and health checking.

## Priority
MEDIUM

## Complexity
LOW

## Dependencies
BUG-003

## Scope

- Add proper upstream block with backend service definition
- Configure health check parameters for upstream
- Add fallback behavior when backend is unavailable (error page)

## Acceptance Criteria

- Nginx starts successfully even when backend is temporarily down
- Upstream block properly defines backend service with keepalive
- Graceful error handling when backend is unreachable

## Checklist

- [x] Add proper upstream block with backend service definition
- [x] Configure health check parameters for upstream
- [x] Add fallback behavior when backend is unavailable (error page)
- [x] Mark this PRD as complete

# Changelog

This PR contains the automated implementation of the task requirements.

Closes #163

## Metrics

```
Time Spent: 00:19:55 (API: 00:16:46)
Turns: 180
Web Searches: 0

Token Usage:
  Input tokens: 390345
  Output tokens: 38764
  Cache creation tokens: 0
  Cache read tokens: 5416064
  Total tokens: 5845173

Per-Model Usage:
  glm-4.5-air:
    Input: 48071, Output: 3991
    Cache read: 93142, Cache create: 0
    Cost: $0.23
  glm-4.7:
    Input: 390345, Output: 38764
    Cache read: 5416064, Cache create: 0
    Cost: $3.38

Context Usage:
  [GLM-4.5-AIR] Context: 70.6% (141213/200000 tokens)
  [GLM-4.7] Context: 2903.2% (5806409/200000 tokens)

Total Cost: $3.61
```

---
🤖 Generated by [Chief Wiggum](https://github.com/0kenx/chief-wiggum)